### PR TITLE
konvertieren des Usermodels von ParseUser zu User 

### DIFF
--- a/lib/data/backend_login.dart
+++ b/lib/data/backend_login.dart
@@ -1,15 +1,71 @@
+import 'package:ReHome/domain/models/user/institution.dart';
 import 'package:parse_server_sdk_flutter/parse_server_sdk_flutter.dart';
+import 'package:ReHome/domain/models/user/user.dart';
+import 'package:ReHome/domain/models/user/id.dart';
+import 'package:ReHome/domain/models/user/name.dart';
+import 'package:ReHome/domain/models/auth/username.dart';
 
 class UserAuth {
   // Authentifizierung von Endbenutzern durch Backend
   // User wird anhand vom gegebenem Nutzernamen und Passwort authentifiziert
-  // Rückgabewert ist der nun eingeloggte Benutzer oder null
-  Future<ParseUser?> authUser(String username, String password) async {
+  // Rückgabewert ist der nun eingeloggte Benutzer (nach unserem Datenmodell) oder null
+  Future<User?> authUser(String username, String password) async {
     final user = ParseUser(username.trim(), password, null);
 
     var response = await user.login();
-    if (response.success) return user;
+    if (response.success) return initUser(user);
     return null;
+  }
+
+  // Bekommt ein ParseUser und macht einen User nach unserer Datenstruktur daraus
+  // Dieser wird zurückgegeben
+  Future<User> initUser(ParseUser parseUser) async {
+    // Erstellt eine Id aus der ObjektId des ParseUsers
+    Id id = Id(parseUser.get('objectId'));
+
+    // Entnimmt den Namen aus dem ParseUser, spaltet ihn in Vor- und Nachname und Erstellt Name-Objekt
+    String nameString = parseUser.get('name');
+    List<String> nameSplit = nameString.split(' ');
+    Name name = Name(nameSplit.first, nameSplit.last);
+
+    // Erstellt Username aus ParseUser-Username
+    Username username = Username.dirty(parseUser.get('username'));
+
+    // Erstellt Insitution aus ParseUser-Institution, falls keine gespeichert ist wird Mock erstellt
+    Institution institution = await initInstitution(parseUser);
+
+    // User-Objekt wird aus Id, Name, Username und Institution erstellt
+    User user = User(id, name, username, institution);
+    return user;
+  }
+
+  // Bekommt einen ParseUser und liest die Institution von diesem
+  // Gibt die Institution in unserem Datenmodel zurück
+  Future<Institution> initInstitution(ParseUser parseUser) async {
+    // Institutions Eintrag in User Datenbank speichern
+    var institutionKey = parseUser.get('institution');
+
+    // Suche nach Institution mit objectId, welcher mit dem Eintrag in User übereinstimmt
+    QueryBuilder<ParseObject> queryInstitution =
+        QueryBuilder<ParseObject>(ParseObject('Institution'))
+          ..whereContains('objectId', institutionKey.get('objectId'));
+
+    // starte query-Suche und speichere die Antwort
+    var response = await queryInstitution.query();
+
+    // Auslesen der Institution falls vorhanden
+    var parseInstitution = response.results!.first;
+
+    // Falls keine Institution gefunden wurde, gebe Institutions-Mock zurück
+    if (!response.success || response.results == null) return Institution.mock;
+
+    // Auslesen des Namens, der Id und dem Department der Institution
+    var institutionName = parseInstitution.get('name');
+    var institutionId = Id(parseInstitution.get('objectId'));
+    var institutionDepartment = parseInstitution.get('department');
+
+    // gebe Institution aus Id, Name und Department zurück
+    return Institution(institutionId, institutionName, institutionDepartment);
   }
 
   // Registrierung von Endbenutzern (NUR für Entwicklungszwecke)

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -1,5 +1,7 @@
 import 'dart:async';
 import 'package:ReHome/data/backend_login.dart';
+import 'package:ReHome/domain/repositories/user_repository.dart';
+import 'package:ReHome/domain/models/user/user.dart';
 
 // Mögliche Authentifizierungszustände
 enum AuthStatus { unknown, authenticated, unauthenticated }
@@ -21,9 +23,11 @@ class AuthRepository {
     required String password,
   }) async {
     // backend Anbindung wird aufgerufen und user wird authentifiziert
-    var user = await UserAuth().authUser(username, password);
-    // Bei erfolgreicher Authentifizierung nutzer übergeben und AuthStatus wird geändert
+    User? user = await UserAuth().authUser(username, password);
+    // Bei erfolgreicher Authentifizierung wird User in UserRepository gesetzt und AuthStatus wird geändert
     if (user != null) {
+      // TODO: User sollte in _userRepository gespeichert werden
+      UserRepository().setUser(user);
       _controller.add(AuthStatus.authenticated);
     } else {
       _controller.add(AuthStatus.unauthenticated);

--- a/lib/domain/repositories/user_repository.dart
+++ b/lib/domain/repositories/user_repository.dart
@@ -5,13 +5,15 @@ import 'package:ReHome/domain/models/user/institution.dart';
 import 'package:ReHome/domain/models/user/name.dart';
 import 'package:ReHome/domain/models/user/user.dart';
 
-import 'package:uuid/uuid.dart';
-
 // Schnittstelle zum Backend für die Abfrage von NutzerDaten.
 // Die Authentifizierung (login/logout) wird vollständig vom 'AuthRepository'
 // übernommen
 class UserRepository {
   User? _user;
+
+  void setUser(User user) {
+    _user = user;
+  }
 
   Future<User?> getUser() async {
     if (_user != null) return _user;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -85,26 +85,10 @@ packages:
     dependency: transitive
     description:
       name: connectivity_plus
-      sha256: "3f8fe4e504c2d33696dac671a54909743bc6a902a9bb0902306f7a2aed7e528e"
+      sha256: b74247fad72c171381dbe700ca17da24deac637ab6d43c343b42867acb95c991
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.9"
-  connectivity_plus_linux:
-    dependency: transitive
-    description:
-      name: connectivity_plus_linux
-      sha256: "3caf859d001f10407b8e48134c761483e4495ae38094ffcca97193f6c271f5e2"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
-  connectivity_plus_macos:
-    dependency: transitive
-    description:
-      name: connectivity_plus_macos
-      sha256: "488d2de1e47e1224ad486e501b20b088686ba1f4ee9c4420ecbc3b9824f0b920"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.6"
+    version: "3.0.6"
   connectivity_plus_platform_interface:
     dependency: transitive
     description:
@@ -113,22 +97,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.4"
-  connectivity_plus_web:
-    dependency: transitive
-    description:
-      name: connectivity_plus_web
-      sha256: "81332be1b4baf8898fed17bb4fdef27abb7c6fd990bf98c54fd978478adf2f1a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.5"
-  connectivity_plus_windows:
-    dependency: transitive
-    description:
-      name: connectivity_plus_windows
-      sha256: "535b0404b4d5605c4dd8453d67e5d6d2ea0dd36e3b477f50f31af51b0aeab9dd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.2"
   convert:
     dependency: transitive
     description:
@@ -181,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: dio
-      sha256: "7d328c4d898a61efc3cd93655a0955858e29a0aa647f0f9e02d59b3bb275e2e8"
+      sha256: a9d76e72985d7087eb7c5e7903224ae52b337131518d127c554b9405936752b8
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.6"
+    version: "5.2.1+1"
   equatable:
     dependency: "direct main"
     description:
@@ -420,66 +388,35 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: f62d7253edc197fe3c88d7c2ddab82d68f555e778d55390ccc3537eca8e8d637
+      sha256: "10259b111176fba5c505b102e3a5b022b51dd97e30522e906d6922c745584745"
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.3+1"
-  package_info_plus_linux:
-    dependency: transitive
-    description:
-      name: package_info_plus_linux
-      sha256: "04b575f44233d30edbb80a94e57cad9107aada334fc02aabb42b6becd13c43fc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_macos:
-    dependency: transitive
-    description:
-      name: package_info_plus_macos
-      sha256: a2ad8b4acf4cd479d4a0afa5a74ea3f5b1c7563b77e52cc32b3ee6956d5482a6
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.0"
+    version: "3.1.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: f7a0c8f1e7e981bc65f8b64137a53fd3c195b18d429fba960babc59a5a1c7ae8
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
-  package_info_plus_web:
-    dependency: transitive
-    description:
-      name: package_info_plus_web
-      sha256: f0829327eb534789e0a16ccac8936a80beed4e2401c4d3a74f3f39094a822d3b
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.6"
-  package_info_plus_windows:
-    dependency: transitive
-    description:
-      name: package_info_plus_windows
-      sha256: "79524f11c42dd9078b96d797b3cf79c0a2883a50c4920dc43da8562c115089bc"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.0"
+    version: "2.0.1"
   parse_server_sdk:
     dependency: transitive
     description:
       name: parse_server_sdk
-      sha256: "0fd3c0111720329577cc8bd34a89edec6ca1d7d70d3d8702af8164acb083a75a"
+      sha256: bf85c1a807849efc380432b8f6c3e91597b6283e7fbbf0151db244de3bef0a5e
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.15"
+    version: "5.1.2"
   parse_server_sdk_flutter:
     dependency: "direct main"
     description:
-      name: parse_server_sdk_flutter
-      sha256: "3462b895ef87a5847de1f2996f7bc252527345f451e25bfc74373692982ae80a"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.3"
+      path: "packages/flutter"
+      ref: f8942ac
+      resolved-ref: f8942ac0a7e5139930c68c870aeb5547e2330100
+      url: "https://github.com/parse-community/Parse-SDK-Flutter.git"
+    source: git
+    version: "5.0.1"
   path:
     dependency: transitive
     description:
@@ -813,6 +750,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  universal_io:
+    dependency: transitive
+    description:
+      name: universal_io
+      sha256: "1722b2dcc462b4b2f3ee7d188dad008b6eb4c40bbd03a3de451d82c78bba9aad"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.2"
   uuid:
     dependency: "direct main"
     description:
@@ -904,4 +849,3 @@ packages:
 sdks:
   dart: ">=3.0.0 <4.0.0"
   flutter: ">=3.3.0"
-


### PR DESCRIPTION
Schließt #33 

Beim Einloggen des Users wird aus Back4App ein ParseUser erstellt, mit den Werten für Namen, Username, Email, Institution, Id und für weiteren (für diesen PR nicht relevanten) Daten. 
Diese Daten werden nun beim Einloggen (in der authUser Funktion in backend_login.dart) zu unserem eigenen Datenmodel konvertiert (durch die initUser Funktion). 
Das hierbei entstandene User-Objekt wird dann zurückgegeben und durch das auth_repository im user_repository gespeichert.

Neue Funktionen für diese Änderungen:
- initUser: konvertiert ParseUser zu User
- initInstitution: sucht durch die im ParseUser gespeicherte Institution-Id nach der Institution und konvertiert das Institution-ParseObject zu einem Institutions-Objekt nach unserem Model

Zum Testen muss Routing geändert werden, da auf main-branch Version login umgangen wurde.

Anmerkung: bislang wird der User im auth_repository in ein neu angelegtes UserRepository gespeichert. Dies wird noch geändert