### PR TITLE
aktueller User im UserRepository verfügbar machen

### DIFF
--- a/lib/business_logic/auth/auth_bloc.dart
+++ b/lib/business_logic/auth/auth_bloc.dart
@@ -21,14 +21,13 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     // registriere passende Handler
     on<AuthStatusChanged>(_onAuthStatusChanged);
     on<AuthLogoutRequested>(_onAuthLogoutRequested);
-    _authStatusSubscription = _authRepository.status.listen(
-      (status) => add(AuthStatusChanged(status)),
-    );
+    _authStatusSubscription = _authRepository.status.listen((streamEvent) =>
+        add(AuthStatusChanged(streamEvent.$1, streamEvent.$2)));
   }
 
   final AuthRepository _authRepository;
   final UserRepository _userRepository;
-  late StreamSubscription<AuthStatus> _authStatusSubscription;
+  late StreamSubscription<(AuthStatus, User?)> _authStatusSubscription;
 
   @override
   Future<void> close() {
@@ -45,12 +44,10 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
       case AuthStatus.unauthenticated:
         return emit(const AuthState.unauthenticated());
       case AuthStatus.authenticated:
-        final user = await _tryGetUser();
-        return emit(
-          user != null
-              ? AuthState.authenticated(user)
-              : const AuthState.unauthenticated(),
-        );
+        if (event.user == null) return emit(const AuthState.unauthenticated());
+        // aktualisiere User im UserRepository
+        _userRepository.setUser(event.user!);
+        return emit(AuthState.authenticated(event.user!));
       case AuthStatus.unknown:
         return emit(const AuthState.unknown());
     }
@@ -62,14 +59,5 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     Emitter<AuthState> emit,
   ) {
     _authRepository.logOut();
-  }
-
-  Future<User?> _tryGetUser() async {
-    try {
-      final user = await _userRepository.getUser();
-      return user;
-    } catch (_) {
-      return null;
-    }
   }
 }

--- a/lib/business_logic/auth/auth_event.dart
+++ b/lib/business_logic/auth/auth_event.dart
@@ -6,9 +6,10 @@ sealed class AuthEvent {
 }
 
 final class AuthStatusChanged extends AuthEvent {
-  const AuthStatusChanged(this.status);
+  const AuthStatusChanged(this.status, this.user);
 
   final AuthStatus status;
+  final User? user;
 }
 
 final class AuthLogoutRequested extends AuthEvent {}

--- a/lib/domain/repositories/auth_repository.dart
+++ b/lib/domain/repositories/auth_repository.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:ReHome/data/backend_login.dart';
-import 'package:ReHome/domain/repositories/user_repository.dart';
 import 'package:ReHome/domain/models/user/user.dart';
 
 // Mögliche Authentifizierungszustände
@@ -9,12 +8,13 @@ enum AuthStatus { unknown, authenticated, unauthenticated }
 // AutheRepository ist die Schnittstelle zwischen Front und Backend
 // für alles was mit Authentifizierung zu tun hat
 class AuthRepository {
-  final _controller = StreamController<AuthStatus>();
+  // stream gibt AuthStatus und User zurück. Der User ist nur bei AuthStatus.authenticated
+  // vorhanden und ansonsten immer null. Dies ist notwendig, damit der AuthBloc dem
+  // UserRepository einen User übergeben kann
+  final _controller = StreamController<(AuthStatus, User?)>();
 
-  Stream<AuthStatus> get status async* {
-    // Mock für backend
-    await Future<void>.delayed(const Duration(seconds: 1));
-    yield AuthStatus.unauthenticated;
+  Stream<(AuthStatus, User?)> get status async* {
+    yield (AuthStatus.unauthenticated, null);
     yield* _controller.stream;
   }
 
@@ -24,18 +24,16 @@ class AuthRepository {
   }) async {
     // backend Anbindung wird aufgerufen und user wird authentifiziert
     User? user = await UserAuth().authUser(username, password);
-    // Bei erfolgreicher Authentifizierung wird User in UserRepository gesetzt und AuthStatus wird geändert
+    // Bei erfolgreicher Authentifizierung wird User und AuthStatus dem AuthBloc per Stream gemeldet
     if (user != null) {
-      // TODO: User sollte in _userRepository gespeichert werden
-      UserRepository().setUser(user);
-      _controller.add(AuthStatus.authenticated);
+      _controller.add((AuthStatus.authenticated, user));
     } else {
-      _controller.add(AuthStatus.unauthenticated);
+      _controller.add((AuthStatus.unauthenticated, null));
     }
   }
 
   void logOut() {
-    _controller.add(AuthStatus.unauthenticated);
+    _controller.add((AuthStatus.unauthenticated, null));
   }
 
   void dispose() => _controller.close();

--- a/lib/domain/repositories/user_repository.dart
+++ b/lib/domain/repositories/user_repository.dart
@@ -1,6 +1,4 @@
-import 'dart:async';
 import 'package:ReHome/domain/models/auth/username.dart';
-import 'package:ReHome/domain/models/user/id.dart';
 import 'package:ReHome/domain/models/user/institution.dart';
 import 'package:ReHome/domain/models/user/name.dart';
 import 'package:ReHome/domain/models/user/user.dart';
@@ -12,6 +10,11 @@ import 'package:parse_server_sdk_flutter/parse_server_sdk_flutter.dart';
 // übernommen
 class UserRepository {
   User? _user;
+
+  // wird vom AuthBloc aufgerufen, um den von AuthRepository erhaltenen User zu übergeben
+  void setUser(User user) {
+    _user = user;
+  }
 
   // aktualisiert Namen des Benutzers und ruft Funktion für Backend Änderung auf
   void updateName(Name name) async {
@@ -49,13 +52,5 @@ class UserRepository {
     }
   }
 
-  Future<User?> getUser() async {
-    if (_user != null) return _user;
-    // Mock für den Nutzer
-    return Future.delayed(
-      const Duration(milliseconds: 300),
-      () => _user =
-          const User(Id.mock, Name.empty, Username.pure(), Institution.mock),
-    );
-  }
+  User? get user => _user;
 }


### PR DESCRIPTION
Schließt #48 

Das AuthRepository übergebit nun zusammen mit dem AuthStatus auch einen User? an den AuthBloc. 
Dieser setzt bei erfolgreichem LogIn den übergebenen User auch im UserRepository.