### PR TITLE
Ergänzung des Datenmodels um DefaultExercise Klasse

### DIFF
--- a/lib/data/backend_exercise.dart
+++ b/lib/data/backend_exercise.dart
@@ -12,9 +12,14 @@ class ExerciseBackend {
     List<ParameterSet> parameters = exercise.parameter;
     Map<DateTime, List<ParameterSet>> results = exercise.results;
 
-    // Erstellung eines Parse Exercise Objects mit der Id
-    ParseObject parseExercise = ParseObject('Exercise')
-      ..set('exerciseType', parseDefaultExercise(exerciseType));
+    // Erstellung eines Parse Exercise Objects
+    ParseObject parseExercise = ParseObject('Exercise');
+
+    // Setzen des exerciseTypes in ParseObject
+    var parsedDefaultExercise = await parseDefaultExercise(exerciseType);
+    if (parsedDefaultExercise != null) {
+      parseExercise.set('exerciseType', parsedDefaultExercise);
+    }
 
     List<ParseObject> parameterList = List.empty(growable: true);
 

--- a/lib/data/backend_exercise.dart
+++ b/lib/data/backend_exercise.dart
@@ -1,3 +1,4 @@
+import 'package:rehome/domain/models/patient/default_exercise.dart';
 import 'package:rehome/domain/models/patient/exercise.dart';
 import 'package:rehome/domain/models/user/id.dart';
 import 'package:parse_server_sdk_flutter/parse_server_sdk_flutter.dart';
@@ -7,12 +8,13 @@ class ExerciseBackend {
   // konvertiert gegebenes Exercise Object zu einem ParseObject
   static Future<ParseObject?> parseExercise(Exercise exercise) async {
     // initialisiert variablen des Exercise Objekts zur angenehmeren Benutzung
-    Id id = exercise.id;
+    DefaultExercise exerciseType = exercise.exerciseType;
     List<ParameterSet> parameters = exercise.parameter;
     Map<DateTime, List<ParameterSet>> results = exercise.results;
 
     // Erstellung eines Parse Exercise Objects mit der Id
-    ParseObject parseExercise = ParseObject('Exercise')..set('typeId', id.id);
+    ParseObject parseExercise = ParseObject('Exercise')
+      ..set('exerciseType', parseDefaultExercise(exerciseType));
 
     List<ParseObject> parameterList = List.empty(growable: true);
 
@@ -26,6 +28,24 @@ class ExerciseBackend {
     parseExercise.addRelation('parameters', parameterList);
 
     ParseResponse response = await parseExercise.save();
+    ParseObject? savedExercise = response.results?.first;
+
+    return savedExercise;
+  }
+
+  // konvertiert gegebenes DefaultExercise Object zu einem ParseObject
+  static Future<ParseObject?> parseDefaultExercise(
+      DefaultExercise exerciseType) async {
+    // initialisiert variablen des DefaultExercise Objekts zur angenehmeren Benutzung
+    String name = exerciseType.name;
+    Id id = exerciseType.id;
+
+    // Erstellung eines Parse Exercise Objects mit der Id und Namen
+    ParseObject parseDefaultExercise = ParseObject('DefaultExercise')
+      ..set('typeId', id.id)
+      ..set('name', name);
+
+    ParseResponse response = await parseDefaultExercise.save();
     ParseObject? savedExercise = response.results?.first;
 
     return savedExercise;

--- a/lib/domain/models/patient/default_exercise.dart
+++ b/lib/domain/models/patient/default_exercise.dart
@@ -1,0 +1,12 @@
+import 'package:rehome/domain/models/user/id.dart';
+import 'package:equatable/equatable.dart';
+
+class DefaultExercise extends Equatable {
+  const DefaultExercise(this.id, this.name);
+
+  final Id id;
+  final String name;
+
+  @override
+  List<Object> get props => [id, name];
+}

--- a/lib/domain/models/patient/exercise.dart
+++ b/lib/domain/models/patient/exercise.dart
@@ -1,15 +1,15 @@
-import 'package:rehome/domain/models/user/id.dart';
+import 'package:rehome/domain/models/patient/default_exercise.dart';
 import 'package:equatable/equatable.dart';
 
 class Exercise extends Equatable {
-  const Exercise(this.id, this.parameter, this.results);
+  const Exercise(this.exerciseType, this.parameter, this.results);
 
-  final Id id;
+  final DefaultExercise exerciseType;
   final List<ParameterSet> parameter;
   final Map<DateTime, List<ParameterSet>> results;
 
   @override
-  List<Object> get props => [id, parameter, results];
+  List<Object> get props => [exerciseType, parameter, results];
 }
 
 abstract class ParameterSet extends Equatable {


### PR DESCRIPTION
Schließt #61 

Dem Datenmodel wurde eine DefaultExercise Klasse hinzugefügt. 
Diese speichert einen Namen und eine Id einer Grundübung. Beim Erstellen eines neuen Exercise Objekts wird ein Objekt der DefaultExercise Klasse abgespeichert und gibt so den Typ / die Grundübung der jeweiligen Übung an. (Die dazugehörigen Parameter einer Übung werden erst in dem Exercise Objekt festgelegt).

Das Backend-Datenmodel wurde diesem neuen Model angepasst und es wurden die Funktionen zum Speichern neuer Übungen angepasst.

Fragen zur Implementation:
- Soll der Klassen Name nochmal angepasst werden, um eine Verwechslung mit der ExerciseDefaultData Klasse auszuschließen? (z.B. ExerciseType o.ä.) Ich hab jetzt zunächst mal den Namen verwendet, den wir im Team Meeting genannt hatten, kann ich aber nochmal ändern falls gewünscht
- Bei einer Backend-Speicherung eines Exercise Objekts wird bislang ein neues DefaultExercise Objekt im backend angelegt. Hier sollte vermutlich zunächst Überprüft werden, ob ein Objekt mit der gegebenen Id bereits vorhanden ist? (Ich hab das zunächst so implementiert, da bisher noch keine DefaultExercise Objekte im Backend angelegt sind)