### PR TITLE
Mock Daten für Patienten

### DIFF
--- a/lib/mocks/mock_clinical_data.dart
+++ b/lib/mocks/mock_clinical_data.dart
@@ -4,9 +4,9 @@ import 'package:rehome/domain/models/patient/clinical_data.dart';
 // Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/clinical_data.dart'
 class ClinicalDataMock {
   // Paresis Sides
-  static ParesisSide both = ParesisSide.both;
-  static ParesisSide left = ParesisSide.left;
-  static ParesisSide right = ParesisSide.right;
+  static const ParesisSide both = ParesisSide.both;
+  static const ParesisSide left = ParesisSide.left;
+  static const ParesisSide right = ParesisSide.right;
 
   // DateTimes
   static DateTime date1 = DateTime(2023, 3, 14, 16, 12, 44, 36);

--- a/lib/mocks/mock_clinical_data.dart
+++ b/lib/mocks/mock_clinical_data.dart
@@ -1,0 +1,76 @@
+import 'package:rehome/domain/models/patient/clinical_data.dart';
+
+// Mocks zum Testen von ClinicalData spezifischen Objekten
+// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/clinical_data.dart'
+class ClinicalDataMock {
+  // Paresis Sides
+  static ParesisSide both = ParesisSide.both;
+  static ParesisSide left = ParesisSide.left;
+  static ParesisSide right = ParesisSide.right;
+
+  // DateTimes
+  static DateTime date1 = DateTime(2023, 3, 14, 16, 12, 44, 36);
+  static DateTime date2 = DateTime(2023, 2, 27, 14, 4, 42, 2);
+  static DateTime date3 = DateTime(2023, 4, 14, 5, 55, 11, 45);
+  static DateTime date4 = DateTime(2023, 5, 21, 13, 13, 55, 14);
+  static DateTime date5 = DateTime(2023, 7, 8, 22, 22, 22, 22);
+  static DateTime date6 = DateTime(2023, 1, 2, 34, 56, 78, 99);
+
+  // Clinical Test Objekte
+  static const ClinicalTest fuglTest1 = FuglMeyerScale(1, 1, 2, 1, 2, "test1");
+  static const ClinicalTest fuglTest2 =
+      FuglMeyerScale(2, 3, 2, 3, 3, "Test am 3.4");
+  static const ClinicalTest fuglTest3 =
+      FuglMeyerScale(2, 0, 1, 2, 0, "Test vom 4.3");
+  static const ClinicalTest fuglTest4 =
+      FuglMeyerScale(1, 0, 0, 0, 1, "Starttest vom 12.2");
+  static const ClinicalTest fuglTest5 =
+      FuglMeyerScale(1, 2, 1, 0, 1, "Wochen Endtest");
+  static const ClinicalTest broetzTest1 =
+      BroetzScale("Test am 4.4", 1, 2, 1, 1);
+  static const ClinicalTest broetzTest2 =
+      BroetzScale("Starttest vom 1.1", 1, 3, 4, 1);
+  static const ClinicalTest broetzTest3 =
+      BroetzScale("Test vom 5.12", 1, 1, 0, 1);
+  static const ClinicalTest broetzTest4 =
+      BroetzScale("erster Test", 0, 0, 0, 1);
+  static const ClinicalTest broetzTest5 =
+      BroetzScale("dritter Test", 1, 4, 1, 2);
+
+  // ClinicalTest Lists
+  static List<ClinicalTest> tests1 = List.empty(growable: true)
+    ..add(fuglTest1)
+    ..add(fuglTest2)
+    ..add(broetzTest1);
+  static List<ClinicalTest> tests2 = List.empty(growable: true)
+    ..add(fuglTest2)
+    ..add(fuglTest3)
+    ..add(fuglTest1);
+  static List<ClinicalTest> tests3 = List.empty(growable: true)
+    ..add(broetzTest1)
+    ..add(broetzTest2)
+    ..add(broetzTest3)
+    ..add(fuglTest2);
+  static List<ClinicalTest> tests4 = List.empty(growable: true)
+    ..add(fuglTest3)
+    ..add(broetzTest1);
+  static List<ClinicalTest> tests5 = List.empty(growable: true)..add(fuglTest4);
+  static List<ClinicalTest> tests6 = List.empty(growable: true)
+    ..add(fuglTest4)
+    ..add(fuglTest5)
+    ..add(broetzTest2)
+    ..add(broetzTest1)
+    ..add(broetzTest3)
+    ..add(broetzTest5);
+
+  // Clinical Data Objekte
+  static ClinicalData clinicalData1 = ClinicalData(left, date1, tests1);
+  static ClinicalData clinicalData2 = ClinicalData(left, date2, tests2);
+  static ClinicalData clinicalData3 = ClinicalData(both, date3, tests3);
+  static ClinicalData clinicalData4 = ClinicalData(both, date2, tests4);
+  static ClinicalData clinicalData5 = ClinicalData(both, date4, tests2);
+  static ClinicalData clinicalData6 = ClinicalData(right, date1, tests5);
+  static ClinicalData clinicalData7 = ClinicalData(right, date4, tests6);
+  static ClinicalData clinicalData8 = ClinicalData(right, date5, tests2);
+  static ClinicalData clinicalData9 = ClinicalData(right, date6, tests3);
+}

--- a/lib/mocks/mock_exercise.dart
+++ b/lib/mocks/mock_exercise.dart
@@ -1,6 +1,8 @@
 import 'package:rehome/domain/models/patient/exercise.dart';
 import 'package:rehome/domain/models/user/id.dart';
 
+import '../domain/models/patient/default_exercise.dart';
+
 // Mocks zum Testen von Exercise spezifischen Objekten
 // Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/exercise.dart'
 class ExerciseMock {
@@ -115,19 +117,33 @@ class ExerciseMock {
     date8_4: parameterListResults3 // cocontractionEllbow, jerkWrist
   };
 
-  // Exercises TODO: nach merge von #65 muss Mock hier geändert werden
+  // DefaultExercises
+  static const DefaultExercise exerciseType1 =
+      DefaultExercise(Id("11"), "Schulter Mobilität");
+  static const DefaultExercise exerciseType2 =
+      DefaultExercise(Id("420"), "Handgelenk-Ellenbogen Streckung");
+  static const DefaultExercise exerciseType3 =
+      DefaultExercise(Id("21"), "Arm Streckung");
+  static const DefaultExercise exerciseType4 =
+      DefaultExercise(Id("512"), "Ellenbogen Mobilität");
+  static const DefaultExercise exerciseType5 =
+      DefaultExercise(Id("69"), "allgemeine Handgelenks Übung ");
+  static const DefaultExercise exerciseType6 =
+      DefaultExercise(Id("23"), "Bewegung des gesamten Arms");
+
+  // Exercises
   static Exercise exercise1 =
-      Exercise(const Id("11"), parameterListShoulder, results1);
+      Exercise(exerciseType1, parameterListShoulder, results1);
   static Exercise exercise2 =
-      Exercise(const Id("420"), parameterListMix1, results2);
+      Exercise(exerciseType2, parameterListMix1, results2);
   static Exercise exercise3 =
-      Exercise(const Id("21"), parameterListMix2, results3);
+      Exercise(exerciseType1, parameterListMix2, results3);
   static Exercise exercise4 =
-      Exercise(const Id("512"), parameterListEllbow, results4);
+      Exercise(exerciseType1, parameterListEllbow, results4);
   static Exercise exercise5 =
-      Exercise(const Id("69"), parameterListWrist, results1);
+      Exercise(exerciseType1, parameterListWrist, results1);
   static Exercise exercise6 =
-      Exercise(const Id("23"), parameterListMix3, results3);
+      Exercise(exerciseType1, parameterListMix3, results3);
 
   // Exercise Lists
   static List<Exercise> exerciseList1 = List.empty(growable: true)

--- a/lib/mocks/mock_exercise.dart
+++ b/lib/mocks/mock_exercise.dart
@@ -1,8 +1,8 @@
 import 'package:rehome/domain/models/patient/exercise.dart';
 import 'package:rehome/domain/models/user/id.dart';
 
-// Mocks zum Testen von Hausaufgaben spezifischen Objekten
-// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/homework.dart'
+// Mocks zum Testen von Exercise spezifischen Objekten
+// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/exercise.dart'
 class ExerciseMock {
   /*
   * ParameterSets

--- a/lib/mocks/mock_exercise.dart
+++ b/lib/mocks/mock_exercise.dart
@@ -1,0 +1,151 @@
+import 'package:rehome/domain/models/patient/exercise.dart';
+import 'package:rehome/domain/models/user/id.dart';
+
+// Mocks zum Testen von Hausaufgaben spezifischen Objekten
+// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/homework.dart'
+class ExerciseMock {
+  /*
+  * ParameterSets
+  */
+  // ParameterSet - Cocontraction Objekte
+  static const ParameterSet cocontractionWrist = Cocontraction(
+      ParameterValue(0.2),
+      ParameterValue(0.1),
+      ParameterValue(0.4),
+      ParameterValue(0.12),
+      ParameterValue(0.9),
+      ParameterValue(0.7),
+      "cocontractionWrist",
+      2);
+  static const ParameterSet cocontractionShoulder = Cocontraction(
+      ParameterValue(0.2),
+      ParameterValue(0.3),
+      ParameterValue(0.7),
+      ParameterValue(0.12),
+      ParameterValue(0.4),
+      ParameterValue(0.2),
+      "cocontractionShoulder",
+      3);
+  static const ParameterSet cocontractionEllbow = Cocontraction(
+      ParameterValue(0.4),
+      ParameterValue(0.123),
+      ParameterValue(0.444),
+      ParameterValue(0.231),
+      ParameterValue(0.48),
+      ParameterValue(0.2002),
+      "cocontractionEllbow",
+      1);
+
+  // ParameterSet - Jerk Objekte
+  static const ParameterSet jerkShoulder =
+      Jerk(ParameterValue(0.1), "jerkShoulder", 4);
+  static const ParameterSet jerkWrist =
+      Jerk(ParameterValue(0.833), "jerkWrist", 5);
+  static const ParameterSet jerkEllbow =
+      Jerk(ParameterValue(0.241), "jerkEllbow", 1);
+
+  // ParameterSet - RangeOfMotion Objekte
+  static const ParameterSet romShoulder =
+      RangeOfMotion(Joint.shoulder, ParameterValue(0.7), "romShoulder", 2);
+  static const ParameterSet romEllbow =
+      RangeOfMotion(Joint.ellbow, ParameterValue(0.1), "romEllbow", 5);
+  static const ParameterSet romWrist =
+      RangeOfMotion(Joint.wrist, ParameterValue(0.4), "romWrist", 3);
+
+  // ParameterSet - Objekt Listen
+  static List<ParameterSet> parameterListShoulder = List.empty(growable: true)
+    ..add(cocontractionShoulder)
+    ..add(jerkShoulder)
+    ..add(romShoulder);
+  static List<ParameterSet> parameterListEllbow = List.empty(growable: true)
+    ..add(cocontractionEllbow)
+    ..add(jerkEllbow)
+    ..add(romEllbow);
+  static List<ParameterSet> parameterListWrist = List.empty(growable: true)
+    ..add(cocontractionWrist)
+    ..add(jerkWrist)
+    ..add(romWrist);
+  static List<ParameterSet> parameterListMix1 = List.empty(growable: true)
+    ..add(cocontractionWrist)
+    ..add(cocontractionEllbow)
+    ..add(jerkWrist)
+    ..add(romWrist);
+  static List<ParameterSet> parameterListMix2 = List.empty(growable: true)
+    ..add(cocontractionShoulder)
+    ..add(jerkShoulder)
+    ..add(cocontractionWrist);
+  static List<ParameterSet> parameterListMix3 = List.empty(growable: true)
+    ..add(romEllbow)
+    ..add(jerkShoulder)
+    ..add(cocontractionWrist);
+  static List<ParameterSet> parameterListResults1 = List.empty(growable: true)
+    ..add(romEllbow);
+  static List<ParameterSet> parameterListResults2 = List.empty(growable: true)
+    ..add(jerkShoulder)
+    ..add(cocontractionWrist);
+  static List<ParameterSet> parameterListResults3 = List.empty(growable: true)
+    ..add(cocontractionEllbow)
+    ..add(jerkWrist);
+
+  /*
+  * Exercises
+  */
+  // Results Maps - DateTimes
+  static DateTime date3_31 = DateTime.utc(2023, 3, 31, 7, 23, 30, 11, 9);
+  static DateTime date1_23 = DateTime.utc(2023, 1, 23, 19, 44, 17, 5, 55);
+  static DateTime date4_20 = DateTime.utc(2023, 4, 20, 16, 20, 00, 4, 20);
+  static DateTime date8_4 = DateTime.utc(2022, 8, 4, 17, 14, 2, 23, 1);
+  static DateTime date9_11 = DateTime.utc(2022, 9, 11, 14, 46, 30, 49, 22);
+
+  // Results Maps
+  static Map<DateTime, List<ParameterSet>> results1 = {
+    date3_31: parameterListResults1, // rowEllbow
+    date1_23: parameterListResults2, // jerkShoulder, cocontractionWrist
+    date4_20: parameterListResults3 // cocontractionEllbow, jerkWrist
+  };
+  static Map<DateTime, List<ParameterSet>> results2 = {
+    date4_20: parameterListResults1, // rowEllbow
+    date8_4: parameterListResults2 // jerkShoulder, cocontractionWrist
+  };
+  static Map<DateTime, List<ParameterSet>> results3 = {
+    date4_20: parameterListResults3 // cocontractionEllbow, jerkWrist
+  };
+  static Map<DateTime, List<ParameterSet>> results4 = {
+    date9_11: parameterListResults1, // rowEllbow
+    date8_4: parameterListResults3 // cocontractionEllbow, jerkWrist
+  };
+
+  // Exercises TODO: nach merge von #65 muss Mock hier geändert werden
+  static Exercise exercise1 =
+      Exercise(const Id("11"), parameterListShoulder, results1);
+  static Exercise exercise2 =
+      Exercise(const Id("420"), parameterListMix1, results2);
+  static Exercise exercise3 =
+      Exercise(const Id("21"), parameterListMix2, results3);
+  static Exercise exercise4 =
+      Exercise(const Id("512"), parameterListEllbow, results4);
+  static Exercise exercise5 =
+      Exercise(const Id("69"), parameterListWrist, results1);
+  static Exercise exercise6 =
+      Exercise(const Id("23"), parameterListMix3, results3);
+
+  // Exercise Lists
+  static List<Exercise> exerciseList1 = List.empty(growable: true)
+    ..add(exercise1)
+    ..add(exercise2);
+  static List<Exercise> exerciseList2 = List.empty(growable: true)
+    ..add(exercise6);
+  static List<Exercise> exerciseList3 = List.empty(growable: true)
+    ..add(exercise1)
+    ..add(exercise3);
+  static List<Exercise> exerciseList4 = List.empty(growable: true)
+    ..add(exercise1)
+    ..add(exercise2)
+    ..add(exercise3)
+    ..add(exercise4)
+    ..add(exercise5)
+    ..add(exercise6);
+  static List<Exercise> exerciseList5 = List.empty(growable: true)
+    ..add(exercise4)
+    ..add(exercise5);
+}

--- a/lib/mocks/mock_goals.dart
+++ b/lib/mocks/mock_goals.dart
@@ -4,27 +4,31 @@ import 'package:rehome/domain/models/patient/goals.dart';
 // Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/goals.dart'
 class GoalsMock {
   // Goal Stati
-  static GoalStatus achieved = GoalStatus.achieved;
-  static GoalStatus active = GoalStatus.active;
-  static GoalStatus inactive = GoalStatus.inactive;
+  static const GoalStatus achieved = GoalStatus.achieved;
+  static const GoalStatus active = GoalStatus.active;
+  static const GoalStatus inactive = GoalStatus.inactive;
 
   // Goal Objekts
-  static Goal goal1 =
+  static const Goal goal1 =
       Goal(active, "Volle Funktionsfähigkeit des linken Arms herstellen");
-  static Goal goal2 = Goal(active, "beide Handgelenk auf 45° überstrecken");
-  static Goal goal3 = Goal(active, "rechten Ellenbogen auf 130° strecken");
-  static Goal goal4 = Goal(active, "linke Schulter um 15° heben");
-  static Goal goal5 =
+  static const Goal goal2 =
+      Goal(active, "beide Handgelenk auf 45° überstrecken");
+  static const Goal goal3 =
+      Goal(active, "rechten Ellenbogen auf 130° strecken");
+  static const Goal goal4 = Goal(active, "linke Schulter um 15° heben");
+  static const Goal goal5 =
       Goal(active, "rechte Hand um 12cm von ebener Oberfläche heben");
-  static Goal goal6 = Goal(inactive, "linke Schulter um über 90° heben");
-  static Goal goal7 = Goal(inactive, "rechtes Handgelenk um 12° neigen");
-  static Goal goal8 = Goal(inactive, "beide Hände um 20cm über Kopf heben");
-  static Goal goal9 =
+  static const Goal goal6 = Goal(inactive, "linke Schulter um über 90° heben");
+  static const Goal goal7 = Goal(inactive, "rechtes Handgelenk um 12° neigen");
+  static const Goal goal8 =
+      Goal(inactive, "beide Hände um 20cm über Kopf heben");
+  static const Goal goal9 =
       Goal(inactive, "Volle Funktionsfähigkeit des rechten Arms herstellen");
-  static Goal goal10 = Goal(achieved, "linkes Handgelenk um 5° beugen");
-  static Goal goal11 =
+  static const Goal goal10 = Goal(achieved, "linkes Handgelenk um 5° beugen");
+  static const Goal goal11 =
       Goal(achieved, "rechten Arm um 23cm von Tischkante heben");
-  static Goal goal12 = Goal(achieved, "linke Schulter auf mehr als 69° heben");
+  static const Goal goal12 =
+      Goal(achieved, "linke Schulter auf mehr als 69° heben");
 
   // Goal Lists
   static List<Goal> goalList1 = List.empty(growable: true)

--- a/lib/mocks/mock_goals.dart
+++ b/lib/mocks/mock_goals.dart
@@ -1,0 +1,60 @@
+import 'package:rehome/domain/models/patient/goals.dart';
+
+// Mocks zum Testen von Goal spezifischen Objekten
+// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/goals.dart'
+class GoalsMock {
+  // Goal Stati
+  static GoalStatus achieved = GoalStatus.achieved;
+  static GoalStatus active = GoalStatus.active;
+  static GoalStatus inactive = GoalStatus.inactive;
+
+  // Goal Objekts
+  static Goal goal1 =
+      Goal(active, "Volle Funktionsfähigkeit des linken Arms herstellen");
+  static Goal goal2 = Goal(active, "beide Handgelenk auf 45° überstrecken");
+  static Goal goal3 = Goal(active, "rechten Ellenbogen auf 130° strecken");
+  static Goal goal4 = Goal(active, "linke Schulter um 15° heben");
+  static Goal goal5 =
+      Goal(active, "rechte Hand um 12cm von ebener Oberfläche heben");
+  static Goal goal6 = Goal(inactive, "linke Schulter um über 90° heben");
+  static Goal goal7 = Goal(inactive, "rechtes Handgelenk um 12° neigen");
+  static Goal goal8 = Goal(inactive, "beide Hände um 20cm über Kopf heben");
+  static Goal goal9 =
+      Goal(inactive, "Volle Funktionsfähigkeit des rechten Arms herstellen");
+  static Goal goal10 = Goal(achieved, "linkes Handgelenk um 5° beugen");
+  static Goal goal11 =
+      Goal(achieved, "rechten Arm um 23cm von Tischkante heben");
+  static Goal goal12 = Goal(achieved, "linke Schulter auf mehr als 69° heben");
+
+  // Goal Lists
+  static List<Goal> goalList1 = List.empty(growable: true)
+    ..add(goal1)
+    ..add(goal2);
+  static List<Goal> goalList2 = List.empty(growable: true)
+    ..add(goal3)
+    ..add(goal5);
+  static List<Goal> goalList3 = List.empty(growable: true)
+    ..add(goal4)
+    ..add(goal6)
+    ..add(goal9);
+  static List<Goal> goalList4 = List.empty(growable: true)
+    ..add(goal1)
+    ..add(goal8)
+    ..add(goal9)
+    ..add(goal10)
+    ..add(goal12);
+  static List<Goal> goalList5 = List.empty(growable: true)
+    ..add(goal7)
+    ..add(goal8);
+  static List<Goal> goalList6 = List.empty(growable: true)
+    ..add(goal6)
+    ..add(goal12);
+
+  // Goals Objekts
+  static Goals goals1 = Goals(goalList1);
+  static Goals goals2 = Goals(goalList2);
+  static Goals goals3 = Goals(goalList3);
+  static Goals goals4 = Goals(goalList4);
+  static Goals goals5 = Goals(goalList5);
+  static Goals goals6 = Goals(goalList6);
+}

--- a/lib/mocks/mock_homework.dart
+++ b/lib/mocks/mock_homework.dart
@@ -1,0 +1,103 @@
+import 'package:rehome/domain/models/patient/homework.dart';
+import 'package:rehome/mocks/mock_exercise.dart';
+
+// Mocks zum Testen von Hausaufgaben spezifischen Objekten
+// Alle hier implementierten Klassen sind zu finden in 'domain/models/patient/homework.dart'
+class HomeworkMock {
+  /*
+  * Exercise Blocks
+  */
+  // Exercise Blocks
+  static ExerciseBlock block1 =
+      ExerciseBlock(ExerciseMock.exerciseList1, BlockStatus.finished);
+  static ExerciseBlock block2 =
+      ExerciseBlock(ExerciseMock.exerciseList2, BlockStatus.unfinished);
+  static ExerciseBlock block3 =
+      ExerciseBlock(ExerciseMock.exerciseList3, BlockStatus.finished);
+  static ExerciseBlock block4 =
+      ExerciseBlock(ExerciseMock.exerciseList4, BlockStatus.unfinished);
+  static ExerciseBlock block5 =
+      ExerciseBlock(ExerciseMock.exerciseList5, BlockStatus.finished);
+  static ExerciseBlock block6 =
+      ExerciseBlock(ExerciseMock.exerciseList3, BlockStatus.unfinished);
+
+  /*
+  * Week Homeworks
+  */
+  // Exercise Block Lists
+  static List<ExerciseBlock> blockList1 = List.empty(growable: true)
+    ..add(block1)
+    ..add(block2);
+  static List<ExerciseBlock> blockList2 = List.empty(growable: true)
+    ..add(block3)
+    ..add(block4)
+    ..add(block5);
+  static List<ExerciseBlock> blockList3 = List.empty(growable: true)
+    ..add(block1)
+    ..add(block3)
+    ..add(block4)
+    ..add(block5);
+  static List<ExerciseBlock> blockList4 = List.empty(growable: true)
+    ..add(block2);
+
+  // exerciseBlock Maps
+  static Map<Day, List<ExerciseBlock>> exerciseMap1 = {
+    Day.monday: blockList1,
+    Day.wednesday: blockList2
+  };
+  static Map<Day, List<ExerciseBlock>> exerciseMap2 = {
+    Day.tuesday: blockList3,
+    Day.friday: blockList4
+  };
+  static Map<Day, List<ExerciseBlock>> exerciseMap3 = {
+    Day.thursday: blockList2,
+    Day.saturday: blockList4,
+    Day.sunday: blockList1
+  };
+
+  // WeekHomeworks
+  static WeekHomework weekHomework1 = WeekHomework(exerciseMap1);
+  static WeekHomework weekHomework2 = WeekHomework(exerciseMap2);
+  static WeekHomework weekHomework3 = WeekHomework(exerciseMap3);
+
+  /*
+  * Homeworks
+  */
+  // Weeks
+  static const Week week1 = Week(12, 2023);
+  static const Week week2 = Week(13, 2023);
+  static const Week week3 = Week(14, 2023);
+  static const Week week4 = Week(23, 2023);
+  static const Week week5 = Week(41, 2023);
+
+  // WeekHomework Maps
+  static Map<Week, WeekHomework> weekHomeMap1 = {
+    week1: weekHomework1,
+    week2: weekHomework2
+  };
+  static Map<Week, WeekHomework> weekHomeMap2 = {week1: weekHomework1};
+  static Map<Week, WeekHomework> weekHomeMap3 = {
+    week1: weekHomework1,
+    week2: weekHomework2,
+    week3: weekHomework2,
+    week4: weekHomework2
+  };
+  static Map<Week, WeekHomework> weekHomeMap4 = {
+    week1: weekHomework3,
+    week4: weekHomework2,
+    week5: weekHomework2
+  };
+
+  // Homeworks
+  // DateTimes aus ExerciseMock werden hier wiederverwendet um keine neuen erstellen zu müssen
+  static Homework homework1 =
+      Homework(weekHomework3, ExerciseMock.date1_23, weekHomeMap1);
+  static Homework homework2 =
+      Homework(weekHomework1, ExerciseMock.date3_31, weekHomeMap3);
+  static Homework homework3 =
+      Homework(weekHomework2, ExerciseMock.date4_20, weekHomeMap2);
+  static Homework homework4 =
+      Homework(weekHomework1, ExerciseMock.date8_4, weekHomeMap4);
+  static Homework homework5 =
+      Homework(weekHomework2, ExerciseMock.date9_11, weekHomeMap3);
+}

--- a/lib/mocks/mock_patient.dart
+++ b/lib/mocks/mock_patient.dart
@@ -42,9 +42,9 @@ class PatientMock {
   static DateTime therapyStart6 = DateTime(2023, 4, 9);
 
   // Patien Stati
-  static PatientStatus active = PatientStatus.active;
-  static PatientStatus inactive = PatientStatus.inactive;
-  static PatientStatus archived = PatientStatus.archived;
+  static const PatientStatus active = PatientStatus.active;
+  static const PatientStatus inactive = PatientStatus.inactive;
+  static const PatientStatus archived = PatientStatus.archived;
 
   // Exercise Default Datas
   static ExerciseDefaultData defaultData1 =

--- a/lib/mocks/mock_patient.dart
+++ b/lib/mocks/mock_patient.dart
@@ -1,0 +1,124 @@
+import 'package:rehome/domain/models/patient/patient.dart';
+import 'package:rehome/domain/models/patient/exercise_default_data.dart';
+import 'package:rehome/domain/models/user/name.dart';
+import 'package:rehome/mocks/mock_clinical_data.dart';
+import 'package:rehome/mocks/mock_exercise.dart';
+import 'package:rehome/mocks/mock_goals.dart';
+import 'package:rehome/mocks/mock_homework.dart';
+
+// Mocks zum Testen von Patient und ExerciseDefaultData Objekten
+// Alle hier implementierten Klassen sind zu finden in:
+// - 'domain/models/patient/patient.dart'
+// - 'domain/models/patient/exercise_default_data.dart.dart'
+class PatientMock {
+  // Names
+  static const Name name1 = Name("Annie", "Leonhart");
+  static const Name name2 = Name("Erwin", "Schmidt");
+  static const Name name3 = Name("Helga", "Haas");
+  static const Name name4 = Name("Uwe", "Underberg");
+  static const Name name5 = Name("Armin", "Arlert");
+  static const Name name6 = Name("Reiner", "Braun");
+
+  // Sex
+  static const Sex female = Sex.female;
+  static const Sex male = Sex.male;
+  static const Sex other = Sex.other;
+  static const Sex none = Sex.unspecified;
+
+  // DateTime - BirthDate
+  static DateTime bDay1 = DateTime(1969, 3, 22);
+  static DateTime bDay2 = DateTime(1972, 10, 14);
+  static DateTime bDay3 = DateTime(1943, 5, 5);
+  static DateTime bDay4 = DateTime(1925, 9, 27);
+  static DateTime bDay5 = DateTime(1980, 11, 3);
+  static DateTime bDay6 = DateTime(1954, 8, 1);
+
+  // DateTime - TherapyStart
+  static DateTime therapyStart1 = DateTime(2022, 11, 11);
+  static DateTime therapyStart2 = DateTime(2023, 2, 28);
+  static DateTime therapyStart3 = DateTime(2023, 5, 30);
+  static DateTime therapyStart4 = DateTime(2023, 3, 22);
+  static DateTime therapyStart5 = DateTime(2022, 12, 21);
+  static DateTime therapyStart6 = DateTime(2023, 4, 9);
+
+  // Patien Stati
+  static PatientStatus active = PatientStatus.active;
+  static PatientStatus inactive = PatientStatus.inactive;
+  static PatientStatus archived = PatientStatus.archived;
+
+  // Exercise Default Datas
+  static ExerciseDefaultData defaultData1 =
+      ExerciseDefaultData(69, ExerciseMock.parameterListShoulder);
+  static ExerciseDefaultData defaultData2 =
+      ExerciseDefaultData(420, ExerciseMock.parameterListEllbow);
+  static ExerciseDefaultData defaultData3 =
+      ExerciseDefaultData(222, ExerciseMock.parameterListWrist);
+  static ExerciseDefaultData defaultData4 =
+      ExerciseDefaultData(31, ExerciseMock.parameterListMix3);
+  static ExerciseDefaultData defaultData5 =
+      ExerciseDefaultData(9, ExerciseMock.parameterListMix2);
+  static ExerciseDefaultData defaultData6 =
+      ExerciseDefaultData(1, ExerciseMock.parameterListMix1);
+
+  // Patients
+  static Patient annieLeonhart = Patient(
+      name1,
+      female,
+      bDay1,
+      therapyStart1,
+      defaultData1,
+      ClinicalDataMock.clinicalData1,
+      GoalsMock.goals1,
+      HomeworkMock.homework1,
+      inactive);
+  static Patient erwinSchmidt = Patient(
+      name2,
+      male,
+      bDay2,
+      therapyStart2,
+      defaultData2,
+      ClinicalDataMock.clinicalData5,
+      GoalsMock.goals2,
+      HomeworkMock.homework2,
+      active);
+  static Patient helgaHaas = Patient(
+      name3,
+      female,
+      bDay3,
+      therapyStart3,
+      defaultData3,
+      ClinicalDataMock.clinicalData2,
+      GoalsMock.goals3,
+      HomeworkMock.homework3,
+      active);
+  static Patient uweUnderberg = Patient(
+      name4,
+      male,
+      bDay4,
+      therapyStart4,
+      defaultData4,
+      ClinicalDataMock.clinicalData7,
+      GoalsMock.goals4,
+      HomeworkMock.homework4,
+      active);
+  static Patient arminArlert = Patient(
+      name5,
+      other,
+      bDay5,
+      therapyStart5,
+      defaultData5,
+      ClinicalDataMock.clinicalData9,
+      GoalsMock.goals5,
+      HomeworkMock.homework1,
+      active);
+  static Patient reinerBraun = Patient(
+      name6,
+      male,
+      bDay6,
+      therapyStart6,
+      defaultData6,
+      ClinicalDataMock.clinicalData3,
+      GoalsMock.goals6,
+      HomeworkMock.homework5,
+      archived);
+}


### PR DESCRIPTION
Schließt #62 

In den Commits wurden Mock Daten zur Erstellung von Patienten erstellt um anschließend Patienten Mocks erstellen zu können.
Hierfür wurde unter `rehome/lib/mocks/` 5 neue Dateien angelegt: 
- [mock_exercise.dart](https://github.com/reTeaming/rehome/compare/main...issue62/bene#diff-fd25f142f412fc2fcadf363ab1479c6b865c0f99a5c8c4c3985668a49e22f45d)
- [mock_homework.dart](https://github.com/reTeaming/rehome/compare/main...issue62/bene#diff-8c3f5e0995c840634a0a46dd5645980412666e059648fe50d01ed28baa006683)
- [mock_goals.dart](https://github.com/reTeaming/rehome/compare/main...issue62/bene#diff-32680e11c860dae9379c2a593ba9345f7ad053cc08beff004f231aaf92ec1c74)
- [mock_clinical_data.dart](https://github.com/reTeaming/rehome/compare/main...issue62/bene#diff-6c787649a528bc58506b85ca520a6c5673a30e9f0b89f191fb601e6c3364e24d)
- [mock_patient.dart](https://github.com/reTeaming/rehome/compare/main...issue62/bene#diff-4a7ed5860f258e0f0ad09f0eb953fe33353ac14bebfe741107e5d52a8c6660bd)

In diesen Dateien wurden jeweils Mocks von Klassen angelegt, welche in den zugehörigen Pendant-Dateien in `rehome/lib/domain/models/patient/` enthalten sind. (Für vereinzelte Klassen wurden zur Vereinfachung die Mocks nicht in extra Dateien erstellt - z.B. ExerciseDefaultData Objekte)
Für jede Klassen wurden mehrere Objekte angelegt, um ein wenig Variation in die Patienten zu bringen.
Die fertigen Mocks der Patienten (6) befinden sich in ´mock_patient.dart´ und wurden mit den Namen des Patienten gespeichert:
- annieLeonhart
- erwinSchmidt
- helgaHaas
- uweUnderberg
- arminArlert
- reinerBraun

Alle erstellten Mocks sind `static` und somit mit `<KlassenName>.<MockName>`  (z.B. `PatientMock.arminArlert`) abrufbar, falls die jeweilige Mock Datei implementiert wurde.

Anmerkung: Nach Merge von #61 / #65 müssen die Exercise Mocks durch die neu implementierte DefaultExercise Klasse ergänzt werden. Nach dieser Ergänzung können die Mocks auch im Backend abgespeichert werden. 
 