### PR TITLE
Issue77/felix: Patientenstatus Anzeige (Status setzen wird später hinzugefügt)

### DIFF
--- a/lib/presentation/patient_page.dart
+++ b/lib/presentation/patient_page.dart
@@ -30,9 +30,9 @@ class PatientPage extends StatelessWidget {
               actions: [
                 PopupMenuButton<String>(
                   icon: switch (state.active!.status) {
-                    PatientStatus.active => Icon(Icons.check),
-                    PatientStatus.archived => Icon(Icons.book),
-                    PatientStatus.inactive => Icon(Icons.snooze)
+                    PatientStatus.active => const Icon(Icons.check),
+                    PatientStatus.archived => const Icon(Icons.book),
+                    PatientStatus.inactive => const Icon(Icons.snooze)
                   },
                   onSelected: (String value) {},
                   itemBuilder: (BuildContext context) =>

--- a/lib/presentation/patient_page.dart
+++ b/lib/presentation/patient_page.dart
@@ -5,6 +5,8 @@ import 'package:rehome/business_logic/patient/patient_bloc.dart';
 import 'package:rehome/domain/models/patient/goals.dart';
 import 'package:rehome/domain/models/patient/homework.dart';
 
+import '../domain/models/patient/patient.dart';
+
 // Screen für die Patientendaten
 class PatientPage extends StatelessWidget {
   const PatientPage({super.key});
@@ -27,6 +29,11 @@ class PatientPage extends StatelessWidget {
             return SliverAppBar(
               actions: [
                 PopupMenuButton<String>(
+                  icon: switch (state.active!.status) {
+                    PatientStatus.active => Icon(Icons.check),
+                    PatientStatus.archived => Icon(Icons.book),
+                    PatientStatus.inactive => Icon(Icons.snooze)
+                  },
                   onSelected: (String value) {},
                   itemBuilder: (BuildContext context) =>
                       <PopupMenuEntry<String>>[

--- a/lib/presentation/patient_page.dart
+++ b/lib/presentation/patient_page.dart
@@ -25,6 +25,26 @@ class PatientPage extends StatelessWidget {
                     DateFormat.yMMMMd().format(state.active!.therapyStart!)
                 : therapyStart = "Kein Startzeitpunkt angegeben";
             return SliverAppBar(
+              actions: [
+                PopupMenuButton<String>(
+                  onSelected: (String value) {},
+                  itemBuilder: (BuildContext context) =>
+                      <PopupMenuEntry<String>>[
+                    const PopupMenuItem<String>(
+                      value: 'Option 1',
+                      child: Text('aktiv'),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Option 2',
+                      child: Text('inaktiv'),
+                    ),
+                    const PopupMenuItem<String>(
+                      value: 'Option 3',
+                      child: Text('archiv'),
+                    ),
+                  ],
+                ),
+              ],
               // Parameter, wann/wie Appbar zu sehen ist
               pinned: false,
               floating: true,


### PR DESCRIPTION
schließt: #77 

Durch diesen PR kann der aktuelle Status eines Patienten (aktiv, inaktiv, archiviert) angezeigt werden.
Dieser erscheint beim anklicken eines Patienten auf der Patientenseite im oberen rechten Eck. Hierbei erscheint, je nach aktuellem Status, folgendes Icon:

- Haken: aktiv
- snooze: inaktiv
- Buch: archiviert

Durch Klicken auf das Icon erscheint ein PopupMenu, durch das der Status des Patienten angepasst werden kann.

Für die Implementierung dieser Funktion wurden folgende Dateien verändert:

`patient_page.dart`

Derzeitig fehlt noch die Möglichkeit den Patientenstatus zu setzen (nur abrufen funktioniert). Diese Möglichkeit wird eingefügt sobald die dafür notwendige Backendanbindung steht möglich ist.